### PR TITLE
feat(server): set /api/css and /api/tailwind to output text/css

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "postinstall": "nuxt prepare"
   },
   "dependencies": {
-    "@poupe/theme-builder": "^0.2.7",
+    "@poupe/theme-builder": "^0.2.8",
     "nuxt": "^3.15.0",
     "uniqolor": "^1.1.1",
     "vue": "latest",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@poupe/theme-builder':
-        specifier: ^0.2.7
-        version: 0.2.7
+        specifier: ^0.2.8
+        version: 0.2.8
       nuxt:
         specifier: ^3.15.0
         version: 3.15.0(@parcel/watcher@2.5.0)(@types/node@22.10.2)(db0@0.2.1)(eslint@9.17.0(jiti@2.4.2))(ioredis@5.4.2)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.29.1)(terser@5.37.0)(typescript@5.7.2)(vite@6.0.6(@types/node@22.10.2)(jiti@2.4.2)(terser@5.37.0)(yaml@2.6.1))(yaml@2.6.1)
@@ -1054,8 +1054,8 @@ packages:
     resolution: {integrity: sha512-WH3SyJNbvcR0qY0VrSqxEOgBS/xfQcVTVH0NlGt1CSLrCddlGbPDrh3FCm8YHZxzdLYXq+zWMm/b5NDlQWtVUw==}
     engines: {node: '>= 18', pnpm: '>= 8'}
 
-  '@poupe/theme-builder@0.2.7':
-    resolution: {integrity: sha512-yAU8uq0Qp9UmeQtxUXigRbomu6f7J1YaNeLxF+pcVBMXL1ywwfnOBOvyOmmhS4YCnCyonGFnNlwIkl3vpbDgTA==}
+  '@poupe/theme-builder@0.2.8':
+    resolution: {integrity: sha512-Upp+XDlknxmBmauO1MGe3Dz8kdDyZFCrI4RWLm/5Vk8oboLMBZ4oV2ktgX9nhwpn5lDwPS1mooOw/gnbnFw4QA==}
     engines: {node: '>= 18', pnpm: '>= 8'}
 
   '@redocly/ajv@8.11.2':
@@ -5573,7 +5573,7 @@ snapshots:
       - jiti
       - supports-color
 
-  '@poupe/theme-builder@0.2.7':
+  '@poupe/theme-builder@0.2.8':
     dependencies:
       '@material/material-color-utilities': 0.3.0
       tailwindcss: 3.4.17

--- a/src/server/api/css/[scheme]/[primary].get.ts
+++ b/src/server/api/css/[scheme]/[primary].get.ts
@@ -1,20 +1,11 @@
-import type {
-  H3Event,
-  EventHandlerRequest,
-} from 'h3';
-
-import type {
-  CSSRuleObject,
-} from 'tailwindcss/types/config';
-
 import {
-  rgbFromHct,
-} from '@poupe/theme-builder/core';
+  type CSSRuleObject,
+  type Hct,
+  type StandardDynamicSchemeKey,
 
-import type {
-  Hct,
-  StandardDynamicSchemeKey,
-} from '~/composables/useColor';
+  rgbFromHct,
+  formatCSSRuleObjects,
+} from '@poupe/theme-builder';
 
 interface ThemeOptions {
   primary: Hct;
@@ -30,11 +21,11 @@ function handleThemeRequest(event: H3Event<EventHandlerRequest>, opt: ThemeOptio
   };
 
   setResponseHeaders(event, {
-    'content-type': 'text/plain; charset=utf-8',
+    'content-type': 'text/css; charset=utf-8',
     'cache-control': 'no-cache',
   });
 
-  return JSON.stringify(theme);
+  return formatCSSRuleObjects(theme);
 };
 
 export default defineEventHandler((e) => {

--- a/src/server/api/tailwind/[scheme]/[primary].get.ts
+++ b/src/server/api/tailwind/[scheme]/[primary].get.ts
@@ -1,20 +1,11 @@
-import type {
-  H3Event,
-  EventHandlerRequest,
-} from 'h3';
-
-import type {
-  CSSRuleObject,
-} from 'tailwindcss/types/config';
-
 import {
-  rgbFromHct,
-} from '@poupe/theme-builder/tailwind';
+  type CSSRuleObject,
+  type Hct,
+  type StandardDynamicSchemeKey,
 
-import type {
-  Hct,
-  StandardDynamicSchemeKey,
-} from '~/composables/useColor';
+  rgbFromHct,
+  formatCSSRuleObjects,
+} from '@poupe/theme-builder/tailwind';
 
 interface ThemeOptions {
   primary: Hct;
@@ -30,11 +21,11 @@ function handleThemeRequest(event: H3Event<EventHandlerRequest>, opt: ThemeOptio
   };
 
   setResponseHeaders(event, {
-    'content-type': 'text/plain; charset=utf-8',
+    'content-type': 'text/css; charset=utf-8',
     'cache-control': 'no-cache',
   });
 
-  return JSON.stringify(theme);
+  return formatCSSRuleObjects(theme);
 };
 
 export default defineEventHandler((e) => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Dependencies**
	- Updated `@poupe/theme-builder` to version `^0.2.8`

- **Improvements**
	- Enhanced theme request handling for CSS and Tailwind configurations
	- Improved response formatting for theme-related API endpoints
	- Updated type imports for theme generation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->