### PR TITLE
feat(server): migrate /api/css and /api/tailwindcss to using makeCSSTheme

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "postinstall": "nuxt prepare"
   },
   "dependencies": {
-    "@poupe/theme-builder": "^0.2.9",
+    "@poupe/theme-builder": "^0.3.0",
     "nuxt": "^3.15.0",
     "uniqolor": "^1.1.1",
     "vue": "latest",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@poupe/theme-builder':
-        specifier: ^0.2.9
-        version: 0.2.9
+        specifier: ^0.3.0
+        version: 0.3.0
       nuxt:
         specifier: ^3.15.0
         version: 3.15.0(@parcel/watcher@2.5.0)(@types/node@22.10.2)(db0@0.2.1)(eslint@9.17.0(jiti@2.4.2))(ioredis@5.4.2)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.29.1)(terser@5.37.0)(typescript@5.7.2)(vite@6.0.6(@types/node@22.10.2)(jiti@2.4.2)(terser@5.37.0)(yaml@2.6.1))(yaml@2.6.1)
@@ -1054,8 +1054,8 @@ packages:
     resolution: {integrity: sha512-WH3SyJNbvcR0qY0VrSqxEOgBS/xfQcVTVH0NlGt1CSLrCddlGbPDrh3FCm8YHZxzdLYXq+zWMm/b5NDlQWtVUw==}
     engines: {node: '>= 18', pnpm: '>= 8'}
 
-  '@poupe/theme-builder@0.2.9':
-    resolution: {integrity: sha512-RcoUK/eIJerT5JegacnOW2vRvOHu4L+vwWpzjqRPCMryqiqN67VNKQbbzGUZFKuGMnSbwGIfRjD1dvVh4f0O4Q==}
+  '@poupe/theme-builder@0.3.0':
+    resolution: {integrity: sha512-JC9KZEVRD+8gN42kSRmXIXH535S2n+fBC4/IdJJh287TSFR4M3V41UierhrsUxjvBg3vB3/GYeOkUmsohUac9A==}
     engines: {node: '>= 18', pnpm: '>= 8'}
 
   '@redocly/ajv@8.11.2':
@@ -5573,7 +5573,7 @@ snapshots:
       - jiti
       - supports-color
 
-  '@poupe/theme-builder@0.2.9':
+  '@poupe/theme-builder@0.3.0':
     dependencies:
       '@material/material-color-utilities': 0.3.0
       tailwindcss: 3.4.17

--- a/src/server/api/css/[scheme]/[primary].get.ts
+++ b/src/server/api/css/[scheme]/[primary].get.ts
@@ -4,7 +4,7 @@ import {
   type StandardDynamicSchemeKey,
 
   formatCSSRuleObjects,
-  makeCSSColors,
+  makeCSSTheme,
 } from '@poupe/theme-builder';
 
 interface ThemeOptions {
@@ -13,7 +13,10 @@ interface ThemeOptions {
 }
 
 function handleThemeRequest(event: H3Event<EventHandlerRequest>, opt: ThemeOptions) {
-  const theme = makeCSSColors(opt.primary, {}, opt.scheme, 0, {
+  const theme = makeCSSTheme({
+    primary: opt.primary,
+  }, {
+    scheme: opt.scheme,
     lightSuffix: '',
     darkSuffix: '',
   });

--- a/src/server/api/tailwindcss/[scheme]/[primary].get.ts
+++ b/src/server/api/tailwindcss/[scheme]/[primary].get.ts
@@ -5,10 +5,6 @@ import {
 
   formatCSSRuleObjects,
   makeCSSTheme,
-} from '@poupe/theme-builder';
-
-import {
-  rgbFromHct,
 } from '@poupe/theme-builder/tailwind';
 
 interface ThemeOptions {
@@ -23,7 +19,6 @@ function handleThemeRequest(event: H3Event<EventHandlerRequest>, opt: ThemeOptio
     scheme: opt.scheme,
     lightSuffix: '',
     darkSuffix: '',
-    stringify: rgbFromHct,
   });
 
   const rules: CSSRuleObject = {

--- a/src/server/api/tailwindcss/[scheme]/[primary].get.ts
+++ b/src/server/api/tailwindcss/[scheme]/[primary].get.ts
@@ -4,7 +4,7 @@ import {
   type StandardDynamicSchemeKey,
 
   formatCSSRuleObjects,
-  makeCSSColors,
+  makeCSSTheme,
 } from '@poupe/theme-builder';
 
 import {
@@ -17,7 +17,10 @@ interface ThemeOptions {
 }
 
 function handleThemeRequest(event: H3Event<EventHandlerRequest>, opt: ThemeOptions) {
-  const theme = makeCSSColors(opt.primary, {}, opt.scheme, 0, {
+  const theme = makeCSSTheme({
+    primary: opt.primary,
+  }, {
+    scheme: opt.scheme,
     lightSuffix: '',
     darkSuffix: '',
     stringify: rgbFromHct,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Dependencies**
  - Updated `@poupe/theme-builder` to version 0.3.0

- **Theme Generation**
  - Migrated theme creation method from `makeCSSColors` to `makeCSSTheme`
  - Updated theme generation process in CSS and Tailwind CSS API endpoints

<!-- end of auto-generated comment: release notes by coderabbit.ai -->