### PR TITLE
feat(deps): update to @poupe/theme-builder 0.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "postinstall": "nuxt prepare"
   },
   "dependencies": {
-    "@poupe/theme-builder": "^0.4.6",
+    "@poupe/theme-builder": "^0.5.0",
     "nuxt": "^3.15.1",
     "uniqolor": "^1.1.1",
     "vue": "latest",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@poupe/theme-builder':
-        specifier: ^0.4.6
-        version: 0.4.6
+        specifier: ^0.5.0
+        version: 0.5.0
       nuxt:
         specifier: ^3.15.1
         version: 3.15.1(@parcel/watcher@2.5.0)(@types/node@22.10.2)(db0@0.2.1)(eslint@9.18.0(jiti@2.4.2))(ioredis@5.4.2)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.29.1)(terser@5.37.0)(typescript@5.7.3)(vite@6.0.7(@types/node@22.10.2)(jiti@2.4.2)(terser@5.37.0)(yaml@2.6.1))(yaml@2.6.1)
@@ -1223,8 +1223,8 @@ packages:
     resolution: {integrity: sha512-graTDvn476QuCIyHP65b48xMvg73cgy9QQp+dUfT1YhoanUvL6Yvp3+YB8+PYjkh1Sz2Zdt5NktmO5J8q8OcLw==}
     engines: {node: '>= 18.20.5', pnpm: '>= 9.15.3'}
 
-  '@poupe/theme-builder@0.4.6':
-    resolution: {integrity: sha512-RVvyKTl++UlFLs7KwI38LGhuLGB7TF3LNo1/AecsCadKvG+czX21A0Dp/iPbuHFFYC1NXwTVKOXybn8rFTQS/w==}
+  '@poupe/theme-builder@0.5.0':
+    resolution: {integrity: sha512-7hXmMbfvKcdHydym2dZc9Z0RSxXotd+VQ5fq6G0adbbvxwUiP6cOdLkh1xpwLkhUTbh8QmtEwATJl34EX4ENoA==}
     engines: {node: '>= 18.20.5', pnpm: '>= 9.15.3'}
 
   '@redocly/ajv@8.11.2':
@@ -3346,8 +3346,8 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  mlly@1.7.3:
-    resolution: {integrity: sha512-xUsx5n/mN0uQf4V548PKQ+YShA4/IW0KI1dZhrNrPCLG+xizETbHTkOa1f8/xut9JRPp8kQuMnz0oqwkTiLo/A==}
+  mlly@1.7.4:
+    resolution: {integrity: sha512-qmdSIPC4bDJXgZTCR7XosJiNKySV7O215tsPtDN9iEO/7q/76b/ijtgRu/+epFXSJhijtTCCGp3DWS549P3xKw==}
 
   mrmime@2.0.0:
     resolution: {integrity: sha512-eu38+hdgojoyq63s+yTpN4XMBdt5l8HhMhc4VKLO9KM5caLIBvUm4thi7fFaxyTmCKeNnXZ5pAlBwCUnhA09uw==}
@@ -3647,8 +3647,8 @@ packages:
   pathe@1.1.2:
     resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
 
-  pathe@2.0.0:
-    resolution: {integrity: sha512-G7n4uhtk9qJt2hlD+UFfsIGY854wpF+zs2bUbQ3CQEUTcn7v25LRsrmurOxTo4bJgjE4qkyshd9ldsEuY9M6xg==}
+  pathe@2.0.1:
+    resolution: {integrity: sha512-6jpjMpOth5S9ITVu5clZ7NOgHNsv5vRQdheL9ztp2vZmM6fRbLvyua1tiBIL4lk8SAe3ARzeXEly6siXCjDHDw==}
 
   perfect-debounce@1.0.0:
     resolution: {integrity: sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==}
@@ -5944,7 +5944,7 @@ snapshots:
       find-up: 7.0.0
       get-port-please: 3.1.2
       h3: 1.13.1
-      mlly: 1.7.3
+      mlly: 1.7.4
       mrmime: 2.0.0
       open: 10.1.0
       picocolors: 1.1.1
@@ -6211,7 +6211,7 @@ snapshots:
       eslint-processor-vue-blocks: 0.1.2(@vue/compiler-sfc@3.5.13)(eslint@9.18.0(jiti@2.4.2))
       globals: 15.14.0
       local-pkg: 0.5.1
-      pathe: 2.0.0
+      pathe: 2.0.1
       vue-eslint-parser: 9.4.3(eslint@9.18.0(jiti@2.4.2))
     transitivePeerDependencies:
       - '@vue/compiler-sfc'
@@ -6240,8 +6240,8 @@ snapshots:
       eslint-typegen: 1.0.0(eslint@9.18.0(jiti@2.4.2))
       find-up: 7.0.0
       get-port-please: 3.1.2
-      mlly: 1.7.3
-      pathe: 2.0.0
+      mlly: 1.7.4
+      pathe: 2.0.1
       unimport: 3.14.5(rollup@4.29.1)
     optionalDependencies:
       vite-plugin-eslint2: 5.0.3(eslint@9.18.0(jiti@2.4.2))(rollup@4.29.1)(vite@6.0.7(@types/node@22.10.2)(jiti@2.4.2)(terser@5.37.0)(yaml@2.6.1))
@@ -6268,9 +6268,9 @@ snapshots:
       jiti: 2.4.2
       klona: 2.0.6
       knitwork: 1.2.0
-      mlly: 1.7.3
+      mlly: 1.7.4
       ohash: 1.1.4
-      pathe: 2.0.0
+      pathe: 2.0.1
       pkg-types: 1.3.0
       scule: 1.3.0
       semver: 7.6.3
@@ -6287,7 +6287,7 @@ snapshots:
     dependencies:
       consola: 3.3.3
       defu: 6.1.4
-      pathe: 2.0.0
+      pathe: 2.0.1
       std-env: 3.8.0
 
   '@nuxt/telemetry@2.6.2(magicast@0.3.5)(rollup@4.29.1)':
@@ -6329,9 +6329,9 @@ snapshots:
       jiti: 2.4.2
       knitwork: 1.2.0
       magic-string: 0.30.17
-      mlly: 1.7.3
+      mlly: 1.7.4
       ohash: 1.1.4
-      pathe: 2.0.0
+      pathe: 2.0.1
       perfect-debounce: 1.0.0
       pkg-types: 1.3.0
       postcss: 8.4.49
@@ -6479,7 +6479,7 @@ snapshots:
       - jiti
       - supports-color
 
-  '@poupe/theme-builder@0.4.6':
+  '@poupe/theme-builder@0.5.0':
     dependencies:
       '@material/material-color-utilities': 0.3.0
       tailwindcss: 3.4.17
@@ -7474,7 +7474,7 @@ snapshots:
       dotenv: 16.4.7
       giget: 1.2.3
       jiti: 2.4.2
-      mlly: 1.7.3
+      mlly: 1.7.4
       ohash: 1.1.4
       pathe: 1.1.2
       perfect-debounce: 1.0.0
@@ -7949,7 +7949,7 @@ snapshots:
 
   eslint-flat-config-utils@1.0.0:
     dependencies:
-      pathe: 2.0.0
+      pathe: 2.0.1
 
   eslint-import-resolver-node@0.3.9:
     dependencies:
@@ -8183,7 +8183,7 @@ snapshots:
   externality@1.0.2:
     dependencies:
       enhanced-resolve: 5.18.0
-      mlly: 1.7.3
+      mlly: 1.7.4
       pathe: 1.1.2
       ufo: 1.5.4
 
@@ -8475,7 +8475,7 @@ snapshots:
   impound@0.2.0(rollup@4.29.1):
     dependencies:
       '@rollup/pluginutils': 5.1.4(rollup@4.29.1)
-      mlly: 1.7.3
+      mlly: 1.7.4
       pathe: 1.1.2
       unenv: 1.10.0
       unplugin: 1.16.0
@@ -8742,7 +8742,7 @@ snapshots:
       h3: 1.13.1
       http-shutdown: 1.2.2
       jiti: 2.4.2
-      mlly: 1.7.3
+      mlly: 1.7.4
       node-forge: 1.3.1
       pathe: 1.1.2
       std-env: 3.8.0
@@ -8754,7 +8754,7 @@ snapshots:
 
   local-pkg@0.5.1:
     dependencies:
-      mlly: 1.7.3
+      mlly: 1.7.4
       pkg-types: 1.3.0
 
   locate-path@5.0.0:
@@ -8901,10 +8901,10 @@ snapshots:
 
   mkdirp@3.0.1: {}
 
-  mlly@1.7.3:
+  mlly@1.7.4:
     dependencies:
       acorn: 8.14.0
-      pathe: 1.1.2
+      pathe: 2.0.1
       pkg-types: 1.3.0
       ufo: 1.5.4
 
@@ -8935,7 +8935,7 @@ snapshots:
   nitro-cloudflare-dev@0.2.1:
     dependencies:
       consola: 3.3.3
-      mlly: 1.7.3
+      mlly: 1.7.4
       pkg-types: 1.3.0
 
   nitropack@2.10.4(typescript@5.7.3):
@@ -8983,7 +8983,7 @@ snapshots:
       magic-string: 0.30.17
       magicast: 0.3.5
       mime: 4.0.6
-      mlly: 1.7.3
+      mlly: 1.7.4
       node-fetch-native: 1.6.4
       ofetch: 1.4.1
       ohash: 1.1.4
@@ -9124,14 +9124,14 @@ snapshots:
       klona: 2.0.6
       knitwork: 1.2.0
       magic-string: 0.30.17
-      mlly: 1.7.3
+      mlly: 1.7.4
       nanotar: 0.1.1
       nitropack: 2.10.4(typescript@5.7.3)
       nuxi: 3.17.2
       nypm: 0.4.1
       ofetch: 1.4.1
       ohash: 1.1.4
-      pathe: 2.0.0
+      pathe: 2.0.1
       perfect-debounce: 1.0.0
       pkg-types: 1.3.0
       radix3: 1.1.2
@@ -9384,7 +9384,7 @@ snapshots:
 
   pathe@1.1.2: {}
 
-  pathe@2.0.0: {}
+  pathe@2.0.1: {}
 
   perfect-debounce@1.0.0: {}
 
@@ -9401,7 +9401,7 @@ snapshots:
   pkg-types@1.3.0:
     dependencies:
       confbox: 0.1.8
-      mlly: 1.7.3
+      mlly: 1.7.4
       pathe: 1.1.2
 
   pluralize@8.0.0: {}
@@ -10224,7 +10224,7 @@ snapshots:
   unenv-nightly@2.0.0-20241218-183400-5d6aec3:
     dependencies:
       defu: 6.1.4
-      mlly: 1.7.3
+      mlly: 1.7.4
       ohash: 1.1.4
       pathe: 1.1.2
       ufo: 1.5.4
@@ -10255,7 +10255,7 @@ snapshots:
       fast-glob: 3.3.2
       local-pkg: 0.5.1
       magic-string: 0.30.17
-      mlly: 1.7.3
+      mlly: 1.7.4
       pathe: 1.1.2
       picomatch: 4.0.2
       pkg-types: 1.3.0
@@ -10280,7 +10280,7 @@ snapshots:
       json5: 2.2.3
       local-pkg: 0.5.1
       magic-string: 0.30.17
-      mlly: 1.7.3
+      mlly: 1.7.4
       pathe: 1.1.2
       scule: 1.3.0
       unplugin: 2.0.0-beta.1
@@ -10343,7 +10343,7 @@ snapshots:
     dependencies:
       knitwork: 1.2.0
       magic-string: 0.30.17
-      mlly: 1.7.3
+      mlly: 1.7.4
       pathe: 1.1.2
       pkg-types: 1.3.0
       unplugin: 1.16.0

--- a/src/components/theme/card.vue
+++ b/src/components/theme/card.vue
@@ -7,10 +7,10 @@
 
 <script setup lang="ts">
 const $props = defineProps<{
-  modelValue: typeof Hct;
+  modelValue: typeof HCT;
   scheme: StandardDynamicSchemeKey;
 }>();
 
-const primary = computed<Hct>(() => $props.modelValue);
-const hexPrimary = computed<HexColor>(() => hexFromHct(primary.value));
+const primary = computed<HCT>(() => $props.modelValue);
+const hexPrimary = computed<HexColor>(() => hexFromHCT(primary.value));
 </script>

--- a/src/components/theme/color-card.vue
+++ b/src/components/theme/color-card.vue
@@ -37,10 +37,10 @@
 import { withShades } from '@poupe/theme-builder/tailwind';
 
 const $props = defineProps<{
-  modelValue: Hct;
+  modelValue: typeof HCT;
 }>();
 
-const hexColor = computed(() => hexFromHct($props.modelValue));
+const hexColor = computed(() => hexFromHCT($props.modelValue));
 
 const shades = computed(() => withShades($props.modelValue));
 </script>

--- a/src/composables/use-color.ts
+++ b/src/composables/use-color.ts
@@ -11,10 +11,10 @@ import {
 
 export {
   type StandardDynamicSchemeKey,
-  Hct,
+  HCT,
 
-  hexFromHct,
-  rgbFromHct,
+  hexFromHCT,
+  rgbFromHCT,
   hct,
 } from '@poupe/theme-builder';
 
@@ -26,8 +26,8 @@ export const isHexValue = (s: string | HexColor): boolean => reHexValue.test(s);
 /** @returns a random color in {@link HexColor} format */
 export const useRandomHexColor = () => uniqolor.random().color as HexColor;
 
-/** useHctColor attempts to convert an string to Hct */
-export const useHctColor = (value: string | string[] = useRandomHexColor()) => {
+/** useHCTColor attempts to convert an string to HCT */
+export const useHCTColor = (value: string | string[] = useRandomHexColor()) => {
   if (!Array.isArray(value))
     return isHexValue(value) ? hct(value) : undefined;
   else if (value.length === 1)
@@ -39,9 +39,10 @@ export const useHctColor = (value: string | string[] = useRandomHexColor()) => {
 export const isThemeSchemeKey = (s: string): boolean => s in standardDynamicSchemes;
 
 /** useThemeScheme attempts to convert an string to a {@link StandardDynamicSchemeKey}. */
-export const useThemeScheme = (value: string) => {
-  if (value in standardDynamicSchemes) {
-    return value as StandardDynamicSchemeKey;
+export const useThemeScheme = (value: string|string[]) => {
+  const key = Array.isArray(value) ? value[0] : value;
+  if (key in standardDynamicSchemes) {
+    return key as StandardDynamicSchemeKey;
   }
   return undefined;
 };

--- a/src/pages/color/[primary].vue
+++ b/src/pages/color/[primary].vue
@@ -9,8 +9,8 @@ definePageMeta({
   validate: (route): boolean => isValidRouteParam('primary', isHexValue, route),
 });
 
-const primary = useHctColor(useRoute().params.primary);
-const hexPrimary = hexFromHct(primary);
+const primary = useHCTColor(useRoute().params.primary);
+const hexPrimary = hexFromHCT(primary);
 
 useHead({
   title: `${hexPrimary} — @poupe/theme-builder`,

--- a/src/pages/theme/[scheme]/[primary].vue
+++ b/src/pages/theme/[scheme]/[primary].vue
@@ -16,8 +16,8 @@ definePageMeta({
 
 const $route = useRoute();
 const scheme = useThemeScheme($route.params.scheme);
-const primary = useHctColor($route.params.primary);
-const hexPrimary = hexFromHct(primary);
+const primary = useHCTColor($route.params.primary);
+const hexPrimary = hexFromHCT(primary);
 
 useHead({
   title: `${scheme}:${hexPrimary} — @poupe/theme-builder`,

--- a/src/server/api/css/[scheme]/[primary].get.ts
+++ b/src/server/api/css/[scheme]/[primary].get.ts
@@ -1,6 +1,6 @@
 import {
   type CSSRuleObject,
-  type Hct,
+  type HCT,
   type StandardDynamicSchemeKey,
 
   formatCSSRuleObjects,
@@ -8,7 +8,7 @@ import {
 } from '@poupe/theme-builder';
 
 interface ThemeOptions {
-  primary: Hct;
+  primary: HCT;
   scheme: StandardDynamicSchemeKey;
 }
 

--- a/src/server/api/tailwindcss/[scheme]/[primary].get.ts
+++ b/src/server/api/tailwindcss/[scheme]/[primary].get.ts
@@ -1,6 +1,6 @@
 import {
   type CSSRuleObject,
-  type Hct,
+  type HCT,
   type StandardDynamicSchemeKey,
 
   formatCSSRuleObjects,
@@ -8,7 +8,7 @@ import {
 } from '@poupe/theme-builder/tailwind';
 
 interface ThemeOptions {
-  primary: Hct;
+  primary: HCT;
   scheme: StandardDynamicSchemeKey;
 }
 

--- a/src/server/utils/theme.ts
+++ b/src/server/utils/theme.ts
@@ -1,24 +1,24 @@
 import {
-  Hct,
+  HCT,
 
-  hexFromHct,
+  hexFromHCT,
 } from '@poupe/theme-builder/core';
 
 import {
   type StandardDynamicSchemeKey,
 
-  useHctColor,
+  useHCTColor,
   useRandomHexColor,
   useThemeScheme,
 } from '~/composables/use-color';
 
-export function hctToURL(c?: Hct) {
+export function hctToURL(c?: HCT) {
   if (c === undefined) {
     return useRandomHexColor().slice(1);
   }
 
-  if (c instanceof Hct) {
-    return hexFromHct(c).slice(1);
+  if (c instanceof HCT) {
+    return hexFromHCT(c).slice(1);
   }
 
   return undefined;
@@ -39,14 +39,14 @@ export function themeSchemeFromRouterParam(event: H3Event<EventHandlerRequest>, 
 }
 
 export function themeColorFromRouterParam(event: H3Event<EventHandlerRequest>, param: string, opts: {
-  fallback?: Hct;
+  fallback?: HCT;
   decode?: boolean;
 } = {}) {
   const s = getRouterParam(event, param, opts);
   let out: typeof opts.fallback;
 
   if (s !== undefined) {
-    out = useHctColor(s);
+    out = useHCTColor(s);
   }
 
   return out === undefined ? opts.fallback : out;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **Dependency Update**
  - Upgraded `@poupe/theme-builder` to version 0.5.0

- **Type and Function Naming**
  - Renamed `Hct` type to `HCT` across multiple components and utilities
  - Updated related function names to match new capitalization (e.g., `hexFromHct` → `hexFromHCT`)
  - Consistent naming conventions applied throughout the project

- **Compatibility**
  - Ensured type consistency in color-related functions and components

<!-- end of auto-generated comment: release notes by coderabbit.ai -->