### PR TITLE
feat(composables): useTheme:  use `prefers-color-scheme` as default

### DIFF
--- a/src/composables/use-theme.ts
+++ b/src/composables/use-theme.ts
@@ -1,10 +1,18 @@
 const defaultThemeColor = '#caae88';
 
+type ColorMode = 'dark' | 'light';
+
+const preferredColorMode = (): ColorMode => 'light';
+
+const cookieName = 'poupe-color-mode';
+const cookieMaxAge = 1000 * 60 * 60 * 24;
+const cookieSameSite = 'lax';
+
 export const useTheme = () => {
-  const themeCookie = useCookie<'dark' | 'light'>('poupe-color-mode', {
-    maxAge: 1000 * 60 * 60 * 24,
-    sameSite: 'lax',
-    default: () => 'light',
+  const themeCookie = useCookie<ColorMode>(cookieName, {
+    maxAge: cookieMaxAge,
+    sameSite: cookieSameSite,
+    default: () => preferredColorMode(),
   });
 
   const darkMode = computed<boolean>({

--- a/src/composables/use-theme.ts
+++ b/src/composables/use-theme.ts
@@ -1,8 +1,13 @@
+import { useMediaQuery } from '@vueuse/core';
+
 const defaultThemeColor = '#caae88';
 
 type ColorMode = 'dark' | 'light';
 
-const preferredColorMode = (): ColorMode => 'light';
+const preferredColorMode = (): ColorMode => {
+  const wantsDark = useMediaQuery('(prefers-color-scheme: dark)');
+  return wantsDark ? 'dark' : 'light';
+};
 
 const cookieName = 'poupe-color-mode';
 const cookieMaxAge = 1000 * 60 * 60 * 24;

--- a/src/composables/use-theme.ts
+++ b/src/composables/use-theme.ts
@@ -1,14 +1,14 @@
 import { useMediaQuery } from '@vueuse/core';
 
 const defaultThemeColor = '#caae88';
-const secondsPerDay = 60*60*24;
+const secondsPerDay = 60 * 60 * 24;
 
 export type ColorMode = 'dark' | 'light';
 
-const preferredColorMode = (): ColorMode => {
+const preferredColorMode = computed((): ColorMode => {
   const wantsDark = useMediaQuery('(prefers-color-scheme: dark)');
   return wantsDark ? 'dark' : 'light';
-};
+});
 
 const cookieName = 'poupe-color-mode';
 const cookieMaxAge = 1000 * secondsPerDay;
@@ -18,7 +18,7 @@ export const useTheme = () => {
   const themeCookie = useCookie<ColorMode>(cookieName, {
     maxAge: cookieMaxAge,
     sameSite: cookieSameSite,
-    default: () => preferredColorMode(),
+    default: () => preferredColorMode.value,
   });
 
   const darkMode = computed<boolean>({

--- a/src/composables/use-theme.ts
+++ b/src/composables/use-theme.ts
@@ -1,8 +1,9 @@
 import { useMediaQuery } from '@vueuse/core';
 
 const defaultThemeColor = '#caae88';
+const secondsPerDay = 60*60*24;
 
-type ColorMode = 'dark' | 'light';
+export type ColorMode = 'dark' | 'light';
 
 const preferredColorMode = (): ColorMode => {
   const wantsDark = useMediaQuery('(prefers-color-scheme: dark)');
@@ -10,7 +11,7 @@ const preferredColorMode = (): ColorMode => {
 };
 
 const cookieName = 'poupe-color-mode';
-const cookieMaxAge = 1000 * 60 * 60 * 24;
+const cookieMaxAge = 1000 * secondsPerDay;
 const cookieSameSite = 'lax';
 
 export const useTheme = () => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a dynamic color mode detection that automatically selects between dark and light themes based on user's system preferences.
	- Enhanced theme management with improved type safety and default value selection based on user preferences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->