### PR TITLE
feat(deps): update @poupe/theme-builder to 0.5.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@iconify-json/heroicons": "^1.2.2",
     "@pinia/nuxt": "^0.9.0",
-    "@poupe/theme-builder": "^0.5.2",
+    "@poupe/theme-builder": "^0.5.3",
     "@vueuse/core": "^12.4.0",
     "nuxt": "^3.15.2",
     "pinia": "^2.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^0.9.0
         version: 0.9.0(magicast@0.3.5)(pinia@2.3.0(typescript@5.7.3)(vue@3.5.13(typescript@5.7.3)))(rollup@4.30.1)
       '@poupe/theme-builder':
-        specifier: ^0.5.2
-        version: 0.5.2
+        specifier: ^0.5.3
+        version: 0.5.3
       '@vueuse/core':
         specifier: ^12.4.0
         version: 12.4.0(typescript@5.7.3)
@@ -1141,8 +1141,8 @@ packages:
     resolution: {integrity: sha512-graTDvn476QuCIyHP65b48xMvg73cgy9QQp+dUfT1YhoanUvL6Yvp3+YB8+PYjkh1Sz2Zdt5NktmO5J8q8OcLw==}
     engines: {node: '>= 18.20.5', pnpm: '>= 9.15.3'}
 
-  '@poupe/theme-builder@0.5.2':
-    resolution: {integrity: sha512-9WdnwMt7FFhqUjg6LBMjIIXm4EhDze6UAuS/xMfPI8E1YrbDY9webY54ljgKxZZnB3o+SDoYv3VsPv9wp45RLw==}
+  '@poupe/theme-builder@0.5.3':
+    resolution: {integrity: sha512-PvrZ9TANE3eimD7sgYfJDTfbDTQg5TAlrhVI5dbYdZHzsqEetSnxzU5e3OgyJp+QnY4oeUlg8YxkVsMbbsjYmw==}
     engines: {node: '>= 18.20.5', pnpm: '>= 9.15.4'}
 
   '@redocly/ajv@8.11.2':
@@ -5993,7 +5993,7 @@ snapshots:
       - jiti
       - supports-color
 
-  '@poupe/theme-builder@0.5.2':
+  '@poupe/theme-builder@0.5.3':
     dependencies:
       '@material/material-color-utilities': 0.3.0
       colord: 2.9.3

--- a/src/components/theme/shades-bar.vue
+++ b/src/components/theme/shades-bar.vue
@@ -21,12 +21,12 @@
 import {
   type Hct,
 
-  withShades,
+  withHexShades,
 } from '@poupe/theme-builder/tailwind';
 
 const props = defineProps<{
   modelValue: Hct;
 }>();
 const hexColor = computed(() => hexFromHct(props.modelValue));
-const shades = computed(() => withShades(props.modelValue));
+const shades = computed(() => withHexShades(props.modelValue));
 </script>

--- a/src/composables/use-color.ts
+++ b/src/composables/use-color.ts
@@ -1,6 +1,7 @@
 import uniqolor from 'uniqolor';
 
 import {
+  type Hct,
   type HexColor,
   type StandardDynamicSchemeKey,
 
@@ -28,12 +29,15 @@ export const useRandomHexColor = () => uniqolor.random().color as HexColor;
 export const useRandomColor = () => hct(useRandomHexColor());
 
 /** useHCTColor attempts to convert an string to {@link Hct} */
-export const useHCTColor = (value: string | string[] = useRandomHexColor()) => {
-  if (!Array.isArray(value))
-    return isHexValue(value) ? hct(value) : undefined;
-  else if (value.length === 1)
-    return isHexValue(value[0]) ? hct(value[0]) : undefined;
-  return undefined;
+export const useHCTColor = (value: string | string[] = useRandomHexColor()): Hct | undefined => {
+  if (!Array.isArray(value)) {
+    if (!isHexValue(value))
+      return undefined;
+
+    return hct(value.startsWith('#') ? value : `#${value}`);
+  }
+
+  return value.length > 0 ? useHCTColor(value[0]) : undefined;
 };
 
 /** @returns if the value is a valid {@link StandardDynamicSchemeKey} */


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Dependencies**
	- Updated `@poupe/theme-builder` to version `^0.5.3`

- **Improvements**
	- Enhanced color handling in `useHCTColor` function
	- Renamed `withShades` function to `withHexShades` in theme component

<!-- end of auto-generated comment: release notes by coderabbit.ai -->