### PR TITLE
fix(composables): fix reHexValue pattern to match exactly 3 or 6 chars

### DIFF
--- a/src/composables/use-color.ts
+++ b/src/composables/use-color.ts
@@ -17,7 +17,7 @@ export {
   hct,
 } from '@poupe/theme-builder';
 
-const reHexValue = /^(#?[0-9a-fA-F]){3,6}$/;
+const reHexValue = /^#?(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/;
 
 /** @returns if the value is a string suitable for {@link hct} */
 export const isHexValue = (s: string | HexColor): boolean => reHexValue.test(s);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved hexadecimal color value validation to ensure more precise matching of color formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->